### PR TITLE
fix: prevent tiles from shifting on focus

### DIFF
--- a/app/src/Components/App/TileBoard/Tile/InputTile/InputTile.styles.ts
+++ b/app/src/Components/App/TileBoard/Tile/InputTile/InputTile.styles.ts
@@ -34,7 +34,6 @@ export const TileStyledTextInput = styled.input<{ $wordLength?: number }>`
     &:focus {
         outline: none;
         box-shadow: 0 0 0 4px ${VariantBorder.focused};
-        margin: 1px;
     }
 
     @media only screen and (width <= 600px) {


### PR DESCRIPTION
Before

https://github.com/imccausl/zombordle/assets/1297096/9ee954e8-bb6d-4300-8570-2d0a39062ace

After


https://github.com/imccausl/zombordle/assets/1297096/594223d8-25b5-4b54-a3c2-20dd837af9db


