### PR TITLE
fix: placement of theme-color meta tag

### DIFF
--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -16,7 +16,6 @@ export default function App({ Component, pageProps }: AppProps) {
     return (
         <>
             <Head>
-                <meta name="theme-color" content="#FFFFFF" />
                 <meta
                     name="description"
                     content="An accessible wordle-like thinger"

--- a/app/src/pages/_document.tsx
+++ b/app/src/pages/_document.tsx
@@ -4,6 +4,7 @@ export default function Document() {
     return (
         <Html lang="en">
             <Head>
+                <meta name="theme-color" content="#FFFFFF" />
                 <link rel="preconnect" href="https://fonts.googleapis.com" />
                 <link
                     rel="preconnect"


### PR DESCRIPTION
Where I had the theme-color meta tag (in _app) was causing some weird behaviour when moving between routes after themes were switched. This should hopefully keep it consistent.